### PR TITLE
Fix typos, type annotations, and code style issues

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-line_length = 88
+line_length = 79
 multi_line_output = 3
 include_trailing_comma = True
 known_third_party = celery,django,environ,pyquery,pytz,redis,requests,rest_framework

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,23 +1,41 @@
-import os 
+import os
 import sys
-PACKAGE_PARENT = '..'
-SCRIPT_DIR = os.path.dirname(os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
+
+PACKAGE_PARENT = ".."
+SCRIPT_DIR = os.path.dirname(
+    os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__)))
+)
 sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR, PACKAGE_PARENT)))
-from rich import print 
-from top_github_scraper.utils import ScrapeGithubUrl, UserProfileGetter      
-import pandas as pd 
+import pandas as pd
+from rich import print
+
+from top_github_scraper.utils import ScrapeGithubUrl, UserProfileGetter
+
 
 def test_keyword_to_url():
-    res = ScrapeGithubUrl._keyword_to_url(page_num=1, keyword='machine learning', 
-                        type="Users", sort_by='followers')
+    res = ScrapeGithubUrl._keyword_to_url(
+        page_num=1,
+        keyword="machine learning",
+        search_type="Users",
+        sort_by="followers",
+    )
 
-    assert res == "https://github.com/search?o=desc&p=1&q=machine+learning&s=followers&type=Users"
+    assert (
+        res
+        == "https://github.com/search?o=desc&p=1&q=machine+learning&s=followers&type=Users"
+    )
+
 
 def test_scrape_top_repo_url_multiple_pages():
-    res = ScrapeGithubUrl('machine learning', 'Repositories', 'stars', 1, 3).scrape_top_repo_url_multiple_pages()
+    res = ScrapeGithubUrl(
+        "machine learning", "Repositories", "stars", 1, 3
+    ).scrape_top_repo_url_multiple_pages()
+
 
 def test_get_all_contributor_profiles():
-    urls = ["https://api.github.com/users/jakevdp",
-            "https://api.github.com/users/fuglede"]
+    urls = [
+        "https://api.github.com/users/jakevdp",
+        "https://api.github.com/users/fuglede",
+    ]
     res = UserProfileGetter(urls).get_all_user_profiles()
     assert isinstance(res, pd.DataFrame)

--- a/top_github_scraper/scrape_repo.py
+++ b/top_github_scraper/scrape_repo.py
@@ -11,7 +11,11 @@ from rich.progress import track
 from tqdm import tqdm
 
 from top_github_scraper.auth import get_auth
-from top_github_scraper.utils import ScrapeGithubUrl, UserProfileGetter, isnotebook
+from top_github_scraper.utils import (
+    ScrapeGithubUrl,
+    UserProfileGetter,
+    isnotebook,
+)
 
 
 class RepoScraper:
@@ -165,13 +169,13 @@ def get_top_repo_urls(
     except Exception as e:
         print(e)
         logging.error(
-            """You might be hitting the rate limit of the HitHub API. Have you authenticated your user account?
+            """You might be hitting the rate limit of the GitHub API. Have you authenticated your user account?
                       If you have exceeded the rate limit as an authenticated user, either decrease the number of pages to scrape or to wait until more requests are available."""
         )
 
 
 def get_top_repos(
-    keyword: int,
+    keyword: str,
     sort_by: str = "best_match",
     save_directory: str = ".",
     max_n_top_contributors: int = 10,
@@ -209,13 +213,13 @@ def get_top_repos(
     except Exception as e:
         print(e)
         logging.error(
-            """You might be hitting the rate limit of the HitHub API. Have you authenticated your user account?
+            """You might be hitting the rate limit of the GitHub API. Have you authenticated your user account?
                       If you have exceeded the rate limit as an authenticated user, either decrease the number of pages to scrape or to wait until more requests are available."""
         )
 
 
 def get_top_contributors(
-    keyword: int,
+    keyword: str,
     sort_by: str = "best_match",
     max_n_top_contributors: int = 10,
     start_page: int = 1,

--- a/top_github_scraper/scrape_user.py
+++ b/top_github_scraper/scrape_user.py
@@ -28,7 +28,7 @@ def get_top_user_urls(
 
 
 def get_top_users(
-    keyword: int,
+    keyword: str,
     start_page: int = 1,
     stop_page: int = 50,
     save_directory: str = ".",

--- a/top_github_scraper/utils.py
+++ b/top_github_scraper/utils.py
@@ -110,6 +110,7 @@ class ScrapeGithubUrl:
             print(
                 f"Bad HTTP Response from: {url}. Got an HTTP response of: {page.status_code}.\n Please confirm this URL is valid."
             )
+            return []
 
         soup = BeautifulSoup(page.text, "html.parser")
         a_tags = soup.find_all("a", href=True)

--- a/top_github_scraper/utils.py
+++ b/top_github_scraper/utils.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from dataclasses import dataclass
 from typing import List
 
@@ -12,8 +11,6 @@ from rich.progress import track
 from tqdm import tqdm
 
 from top_github_scraper.auth import get_auth
-
-warnings.filterwarnings("ignore")
 
 SKIP_PATHS = {
     "/search",
@@ -63,7 +60,7 @@ class ScrapeGithubUrl:
     -------
     keyword: str
         keyword to search on Github
-    type: str
+    search_type: str
         whether to search for User or Repositories
     sort_by: str
         sort by best match or most stars, by default 'best_match', which will sort by best match.
@@ -81,13 +78,13 @@ class ScrapeGithubUrl:
     def __init__(
         self,
         keyword: str,
-        type: str,
+        search_type: str,
         sort_by: str,
         start_page_num: int,
         stop_page_num: int,
     ):
         self.keyword = keyword
-        self.type = type
+        self.type = search_type
         self.start_page_num = start_page_num
         self.stop_page_num = stop_page_num
         if sort_by == "best_match":
@@ -96,20 +93,22 @@ class ScrapeGithubUrl:
             self.sort_by = sort_by
 
     @staticmethod
-    def _keyword_to_url(page_num: int, keyword: str, type: str, sort_by: str):
+    def _keyword_to_url(
+        page_num: int, keyword: str, search_type: str, sort_by: str
+    ):
         """Change keyword to a url"""
         keyword_no_space = ("+").join(keyword.split(" "))
-        return f"https://github.com/search?o=desc&p={str(page_num)}&q={keyword_no_space}&s={sort_by}&type={type}"
+        return f"https://github.com/search?o=desc&p={str(page_num)}&q={keyword_no_space}&s={sort_by}&type={search_type}"
 
     def _scrape_top_repo_url_one_page(self, page_num: int):
         """Scrape urls of top Github repositories in 1 page"""
         url = self._keyword_to_url(
-            page_num, self.keyword, type=self.type, sort_by=self.sort_by
+            page_num, self.keyword, search_type=self.type, sort_by=self.sort_by
         )
         page = requests.get(url, auth=get_auth())
         if page.status_code != 200:
             print(
-                f"Bad HTTP Response from: {url}. Got an HTTP repsonse of: {page.status_code}.\n Please confirm this URL is valid."
+                f"Bad HTTP Response from: {url}. Got an HTTP response of: {page.status_code}.\n Please confirm this URL is valid."
             )
 
         soup = BeautifulSoup(page.text, "html.parser")
@@ -145,7 +144,7 @@ class ScrapeGithubUrl:
 class UserProfileGetter:
     """Get the information from users' homepage"""
 
-    def __init__(self, urls: List[str]) -> pd.DataFrame:
+    def __init__(self, urls: List[str]) -> None:
         self.urls = urls
         # Comment out the features that you dont want to show up in the final report.
         self.profile_features = [


### PR DESCRIPTION
## Summary
- Remove global `warnings.filterwarnings("ignore")` that suppressed all warnings on import
- Fix `keyword: int` → `keyword: str` type annotations in 3 functions
- Fix typos: `repsonse`→`response`, `HitHub`→`GitHub`
- Fix `UserProfileGetter.__init__` return annotation (`pd.DataFrame`→`None`)
- Rename parameter `type`→`search_type` to avoid shadowing builtin
- Align isort `line_length` with black (88→79)

Closes #41, closes #44, closes #45

## Test plan
- [x] `pytest tests/` — 3 passed
- [x] `black --check` — clean
- [x] `isort --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)