### PR TITLE
Fix critical bugs in URL construction, error handling, and file caching

### DIFF
--- a/top_github_scraper/scrape_repo.py
+++ b/top_github_scraper/scrape_repo.py
@@ -48,6 +48,15 @@ class RepoScraper:
             logging.error(
                 f"You are getting a bad HTTP response when you are requesting info from this URL: {repo_info_url}"
             )
+            return {
+                "stargazers_count": 0,
+                "forks_count": 0,
+                "contributors": {
+                    "login": [],
+                    "url": [],
+                    "contributions": [],
+                },
+            }
         repo_info = http_response.json()
         info_to_scrape = ["stargazers_count", "forks_count"]
         repo_important_info = {}

--- a/top_github_scraper/scrape_user.py
+++ b/top_github_scraper/scrape_user.py
@@ -18,13 +18,15 @@ def get_top_user_urls(
 
     See PARAMETERs.md for a description of the parameters of this function
     """
+    safe_keyword = keyword.replace(" ", "_")
     Path(save_directory).mkdir(parents=True, exist_ok=True)
-    save_path = f"{save_directory}/top_repo_urls_{keyword}_{start_page}_{stop_page}.json"
+    save_path = f"{save_directory}/top_repo_urls_{safe_keyword}_{start_page}_{stop_page}.json"
     repo_urls = ScrapeGithubUrl(
         keyword, "Users", "followers", start_page, stop_page
     ).scrape_top_repo_url_multiple_pages()
     with open(save_path, "w") as outfile:
         json.dump(repo_urls, outfile)
+    return repo_urls
 
 
 def get_top_users(
@@ -53,11 +55,6 @@ def get_top_users(
         user_urls = json.load(infile)
         url = "https://api.github.com/users"
         urls = [url + user for user in user_urls]
-        for i in range(len(urls)):
-            # This is what the HTTP requet needs to be formatted: https://api.github.com/users/ZuzooVn
-            # We need to remove the last part of the URL, after the final '/', to use the API correctly.
-            index = urls[i].rfind("/")
-            urls[i] = urls[i][:index]
         top_users = UserProfileGetter(urls).get_all_user_profiles()
         top_users.to_csv(user_save_path)
         return top_users

--- a/top_github_scraper/scrape_user.py
+++ b/top_github_scraper/scrape_user.py
@@ -20,7 +20,7 @@ def get_top_user_urls(
     """
     safe_keyword = keyword.replace(" ", "_")
     Path(save_directory).mkdir(parents=True, exist_ok=True)
-    save_path = f"{save_directory}/top_repo_urls_{safe_keyword}_{start_page}_{stop_page}.json"
+    save_path = f"{save_directory}/top_user_urls_{safe_keyword}_{start_page}_{stop_page}.json"
     repo_urls = ScrapeGithubUrl(
         keyword, "Users", "followers", start_page, stop_page
     ).scrape_top_repo_url_multiple_pages()
@@ -42,7 +42,7 @@ def get_top_users(
     See PARAMETERs.md for a description of the parameters of this function.
     """
     safe_keyword = keyword.replace(" ", "_")
-    full_url_save_path = f"{save_directory}/top_repo_urls_{safe_keyword}_{start_page}_{stop_page}.json"
+    full_url_save_path = f"{save_directory}/top_user_urls_{safe_keyword}_{start_page}_{stop_page}.json"
     user_save_path = f"{save_directory}/top_user_info_{safe_keyword}_{start_page}_{stop_page}.csv"
     if not Path(full_url_save_path).exists():
         get_top_user_urls(


### PR DESCRIPTION
## Summary
- **get_top_users URL fix (#38):** Remove `rfind("/")` truncation loop that was destroying valid user API URLs (e.g. `https://api.github.com/users/username` → `https://api.github.com/users`)
- **_get_repo_information error handling (#39):** Add early return with valid data structure on non-200 HTTP response, preventing `KeyError` on missing `stargazers_count`/`forks_count`
- **get_top_user_urls filename + return (#40):** Use `safe_keyword` (spaces→underscores) in filename to match `get_top_users`, and add missing `return repo_urls`

Closes #38, closes #39, closes #40

## Test plan
- [x] `pytest tests/` — 3 passed
- [ ] Manual: `get_top_users("machine learning", stop_page=2)` should fetch real user profiles
- [ ] Manual: `get_top_user_urls("machine learning")` should return a list (not None)

🤖 Generated with [Claude Code](https://claude.com/claude-code)